### PR TITLE
Add compiler option -funroll-loops

### DIFF
--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@
 #
 .SUFFIXES: .cpp .o .c .h
 
-CFLAGS = -std=gnu99 -ggdb  -O2 -mavx  -march=native -Wall -Wextra
+CFLAGS = -std=gnu99 -ggdb  -O2 -mavx  -march=native -Wall -Wextra -funroll-loops
 CXXFLAGS = -O2 -mavx  -march=native
 
 all: clmulunit variablelengthbenchmark  benchmark benchmark64bitreductions uniformsanity smhasher benchmark128bitmultiplication benchmark128bitpolyhashing


### PR DESCRIPTION
This leads to substantial speed improvements on my machine
in some of the benchmarks, most notably "GFMultilinear (half
multiplication)" and "unrolled Horner".

Before:

Google's City                        CPU cycle/byte = 0.216868   billions of bytes per second =  16.560870  
64-bit VHASH                         CPU cycle/byte = 0.244662   billions of bytes per second =  14.679425  
64-bit CLHASH                        CPU cycle/byte = 0.156680   billions of bytes per second =  22.922380  
GFMultilinear                        CPU cycle/byte = 0.241793   billions of bytes per second =  14.854034  
GFMultilinear (half multiplication)  CPU cycle/byte = 0.153881   billions of bytes per second =  23.339031  
SipHash                              CPU cycle/byte = 1.967911   billions of bytes per second =  1.825117  
GHASH                                CPU cycle/byte = 0.871050   billions of bytes per second =  4.123296  
hornerHash                           CPU cycle/byte = 0.584112   billions of bytes per second =  6.148765  
unrolled Horner                      CPU cycle/byte = 0.537317   billions of bytes per second =  6.684291  
twice Horner32                       CPU cycle/byte = 1.167224   billions of bytes per second =  3.077085    

After:

Google's City                        CPU cycle/byte = 0.217142   billions of bytes per second =  16.539471  
64-bit VHASH                         CPU cycle/byte = 0.251299   billions of bytes per second =  14.292194  
64-bit CLHASH                        CPU cycle/byte = 0.146916   billions of bytes per second =  24.444975  
GFMultilinear                        CPU cycle/byte = 0.236935   billions of bytes per second =  15.158019  
GFMultilinear (half multiplication)  CPU cycle/byte = 0.128006   billions of bytes per second =  28.056716  
SipHash                              CPU cycle/byte = 1.984136   billions of bytes per second =  1.810179  
GHASH                                CPU cycle/byte = 0.736857   billions of bytes per second =  4.874218  
hornerHash                           CPU cycle/byte = 0.591618   billions of bytes per second =  6.070756  
unrolled Horner                      CPU cycle/byte = 0.357963   billions of bytes per second =  10.033560  
twice Horner32                       CPU cycle/byte = 1.174975   billions of bytes per second =  3.056785
