### PR TITLE
Improve stability of benchmark.

### DIFF
--- a/src/variablelengthbenchmark.c
+++ b/src/variablelengthbenchmark.c
@@ -111,7 +111,6 @@ int main(int c, char ** arg) {
     int i, j;
     int length;
     int SHORTTRIALS;
-    ticks bef, aft;
     struct timeval start, finish;
     uint64_t randbuffer[150] __attribute__ ((aligned (16)));// 150 should be plenty
     uint32_t sumToFoolCompiler = 0;
@@ -132,7 +131,7 @@ int main(int c, char ** arg) {
     printf("\n");
     fflush(stdout);
     for (length = lengthStart; length <= lengthEnd; length += 1) {
-        SHORTTRIALS = 40000000 / length;
+        SHORTTRIALS = 80000000 / length;
         printf("%8d \t\t", length);
         hashFunction64 thisfunc64;
         for (i = 0; i < HowManyFunctions64; ++i) {
@@ -141,13 +140,17 @@ int main(int c, char ** arg) {
             thisfunc64 = funcArr64[i];
             sumToFoolCompiler += thisfunc64(randbuffer, intstring, length); // we do not count the first one
             gettimeofday(&start, 0);
-            bef = startRDTSC();
+            ticks lowest = ~(ticks)0;
             for (j = 0; j < SHORTTRIALS; ++j) {
+                const ticks bef = startRDTSC();
                 sumToFoolCompiler += thisfunc64(randbuffer, intstring, length);
+                const ticks aft = stopRDTSCP();
+                const ticks diff = aft-bef;
+                lowest = (lowest < diff) ? lowest : diff;
             }
-            aft = stopRDTSCP();
             gettimeofday(&finish, 0);
-            printf(" %f ", (aft - bef) * 1.0 / (8.0 * SHORTTRIALS * length));
+            printf(" %f ", lowest * 1.0 / (8.0 * length));
+            fflush(stdout);
         }
         printf("\n");
     }


### PR DESCRIPTION
On my machine, this change decreases the variance significantly.

This commit also include a fflush(stdout), to make tail -f'ing the
output more useful.
