### PR TITLE
Reduce the number of multiplications in unrolledHorner by 33%.

### DIFF
--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -94,7 +94,7 @@ hashFunction64 funcArr64[HowManyFunctions64] = {&hashCity,
                                                 &hashSipHash,
                                                 &GHASH64bit,
                                                 &hornerHash,
-                                                &unrolledHorner,
+                                                &unrolledHorner4,
                                                 &twiceHorner32
                                                };
 

--- a/src/variablelengthbenchmark.c
+++ b/src/variablelengthbenchmark.c
@@ -82,7 +82,7 @@ ticks stopRDTSCP(void) {
 hashFunction64 funcArr64[HowManyFunctions64] = { &hashVHASH64, &CLHASH,
                                                  &hashCity, &hashSipHash,&GHASH64bit
                                                 ,&hornerHash
-                                                ,&unrolledHorner
+                                                ,&unrolledHorner4
                                                 ,&twiceHorner32
                                                };
 


### PR DESCRIPTION
Also parameterize it by its parallelism. This creates a speedup of
10-25% on my machine.
