### PR TITLE
Add some consts to make type signatures match

### DIFF
--- a/include/bigendianuniversal.h
+++ b/include/bigendianuniversal.h
@@ -84,7 +84,7 @@ static inline void univHash(const uint64_t h0, const uint64_t h1,
 // supports it.
 #define DECLARE_UNROLLED_HORNER(MANY)                                        \
   uint64_t unrolledHorner##MANY(const void *randomSource, const uint64_t *x, \
-                                uint64_t length) {                           \
+                                const uint64_t length) {                     \
     uint64_t accums[MANY];                                                   \
     accums[0] = length;                                                      \
     accums[1] = x[1];                                                        \
@@ -130,8 +130,8 @@ DECLARE_UNROLLED_HORNER(9)
 // This function is unrolled in a manenr similar to unrolledHorner,
 // above.
 uint64_t twiceHorner32(const void * randomSource,
-                        const uint64_t * x,
-                        uint64_t length) {
+                       const uint64_t * x,
+                       const uint64_t length) {
   u128 h;
   memcpy(&h, randomSource, sizeof(u128));
   // h.lo and h.hi must be odd:


### PR DESCRIPTION
`hashFunction64`, in hashfunctions64bits.h, expects the length parameter to be const.
