### PR TITLE
Add a CLNH variant of Boesgaard et al.'s Badger

### DIFF
--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -84,7 +84,7 @@ static __inline__ ticks fancystopRDTSCP(void) {
 #include "bigendianuniversal.h"
 
 #define HowManyFunctions 12
-#define HowManyFunctions64 11
+#define HowManyFunctions64 12
 
 hashFunction64 funcArr64[HowManyFunctions64] = {&hashCity,
                                                 &hashVHASH64,
@@ -97,6 +97,7 @@ hashFunction64 funcArr64[HowManyFunctions64] = {&hashCity,
                                                 &unrolledHorner4,
                                                 &twiceHorner32
                                                 ,&iterateCL11
+                                                ,&treeCL9
                                                };
 
 hashFunction funcArr[HowManyFunctions] = {&hashGaloisFieldMultilinear,
@@ -117,6 +118,7 @@ const char* functionnames64[HowManyFunctions64] = {
     "unrolled Horner                     ",
     "twice Horner32                      "
     ,"iterateCL 11                        "
+    ,"treeCL 9                            "
 };
 
 const char* functionnames[HowManyFunctions] = {

--- a/src/variablelengthbenchmark.c
+++ b/src/variablelengthbenchmark.c
@@ -77,7 +77,7 @@ ticks stopRDTSCP(void) {
 #include "ghash.h"
 #include "bigendianuniversal.h"
 
-#define HowManyFunctions64 9
+#define HowManyFunctions64 10
 
 hashFunction64 funcArr64[HowManyFunctions64] = { &hashVHASH64, &CLHASH,
                                                  &hashCity, &hashSipHash,&GHASH64bit
@@ -85,6 +85,7 @@ hashFunction64 funcArr64[HowManyFunctions64] = { &hashVHASH64, &CLHASH,
                                                 ,&unrolledHorner4
                                                 ,&twiceHorner32
                                                  ,&iterateCL11
+                                                 ,&treeCL9
                                                };
 
 const char* functionnames64[HowManyFunctions64] = { "64-bit VHASH        ",
@@ -93,6 +94,7 @@ const char* functionnames64[HowManyFunctions64] = { "64-bit VHASH        ",
                                                     "unrolled Horner     ",
                                                     "twice Horner32      "
                                                     ,"iterateCL 11        "
+                                                    ,"treeCL9"
                                                   };
 
 int main(int c, char ** arg) {


### PR DESCRIPTION
In my experiments, this is slower than CLHASH, but faster than VHASH.

To hash It uses 3 + 2 \* log_2(n+1) 64-bit words to hash n 64-bit words down to one. The resulting word is O(log_2(n+1)/2^64)-almost big-endian universal.
