### PR TITLE
Convert variable length benchmark to C++.

### DIFF
--- a/include/bigendianuniversal.h
+++ b/include/bigendianuniversal.h
@@ -132,7 +132,7 @@ uint64_t twiceHorner32(const void * randomSource,
   // View the input as 32-bit ints:
   const uint32_t * x = (const uint32_t *)y;
   // View the random data as 64-bit ints:
-  const uint64_t * r = randomSource;
+  const uint64_t * r = (const uint64_t *)randomSource;
   // Both must be odd
   uint64_t h1 = r[0] | 0x1ull;
   uint64_t h2 = r[1] | 0x1ull;

--- a/include/bigendianuniversal.h
+++ b/include/bigendianuniversal.h
@@ -34,8 +34,9 @@ static inline uint64_t hi64mul(uint64_t x, uint64_t y) {
 // Multiply two u128s, but don't compute the least significant 64 bits
 // or the most significant 128 bits.
 static inline u128 multHi128(u128 x, u128 y) {
-  return (u128) {.hi = x.hi * y.lo + x.lo * y.hi + hi64mul(x.lo, y.lo),
-                 .lo = 0};
+  const u128 result = {x.hi * y.lo + x.lo * y.hi + hi64mul(x.lo, y.lo),
+                       0};
+  return result;
 }
 
 // An L*2^{1-d} almost bigendian universal hash function on strings of
@@ -49,7 +50,8 @@ uint64_t hornerHash(const void * randomSource,
   h.lo |= 1;
   // We treat the length as the first word in the string, ensuring
   // that no string is a prefix of any other.
-  u128 accum = multHi128(h, (u128) {.hi = length, .lo = x[0]});
+  u128 accum = {length, x[0]};
+  accum = multHi128(h, accum);
   for (size_t i = 1; i < length; ++i) {
     // accum.hi holds the hash value we have accumulated so far. We
     // put the next word to hash into accum.lo to make one two-word
@@ -138,15 +140,18 @@ uint64_t twiceHorner32(const void * randomSource,
   h.lo |= 1;
   h.hi |= 1;
   if (1 == length) {
-    return multHi128(h, (u128) {.hi = length, .lo = x[0]}).hi;
+    const u128 tmp = {length, x[0]};
+    return multHi128(h, tmp).hi;
   }
   if (2 == length) {
-    u128 tmp = multHi128(h, (u128) {.hi = length, .lo = x[0]});
+    u128 tmp = {length, x[0]};
+    tmp = multHi128(h, tmp);
     tmp.lo = x[1];
     return multHi128(h, tmp).hi;
   }
-  u128 accums[4] = {(u128) {.hi = length}, (u128) {.hi = x[0]},
-                    (u128) {.hi = x[1]}, (u128) {.hi = x[2]}};
+  u128 accums[4];
+  accums[0].hi = length; accums[1].hi = x[0];
+  accums[2].hi = x[1]; accums[3].hi = x[2];
   size_t i = 3;
   // This is the main loop.
   for (; i + 3 < length; i += 4) {
@@ -180,10 +185,11 @@ uint64_t twiceHorner32(const void * randomSource,
 
 // Using the random words in `r64`, universally hash `data` down to 64 bits
 static inline uint64_t bigHashDown(const uint64_t *r64, const __m128i *data) {
-  uint64_t d64[2] = {_mm_extract_epi64(*data, 0),
-                     _mm_extract_epi64(*data, 1)};
-  univHash(r64[0], r64[1], d64[0], &d64[1]);
-  return d64[1];
+  int64_t d64[2] = {_mm_extract_epi64(*data, 0),
+                    _mm_extract_epi64(*data, 1)};
+  uint64_t * u64 = (uint64_t *)d64;
+  univHash(r64[0], r64[1], u64[0], &u64[1]);
+  return u64[1];
 }
 
 // Big-endian universally hash `data` with the random bits in `r64`.

--- a/include/hashfunctions32bits.h
+++ b/include/hashfunctions32bits.h
@@ -197,13 +197,14 @@ uint32_t pyramidal_Multilinear(const void *  randomsource, const uint32_t *  str
     int newlength = ((length+blocksize-1)/blocksize);
     uint32_t * array = (uint32_t *)  malloc(newlength * sizeof(uint32_t));
     __hashMulti(randomsource, string, array,  length, blocksize);
-    randomsource+=blocksize+1;
+    const char * randomChars = (const char *)randomsource;
+    randomChars+=blocksize+1;
     length = newlength;
     while(length>1) {
         newlength = ((length+blocksize-1)/blocksize);
         uint32_t * array2 = (uint32_t *) malloc(newlength * sizeof(uint32_t));
-        __hashMulti(randomsource, array, array2,  length, blocksize);
-        randomsource+=blocksize+1;
+        __hashMulti(randomChars, array, array2,  length, blocksize);
+        randomChars+=blocksize+1;
         free(array);
         array = array2;
         length = newlength;

--- a/include/hashfunctions64bits.h
+++ b/include/hashfunctions64bits.h
@@ -19,7 +19,7 @@ uint64_t hashCity(const void*  rs, const uint64_t *  string, const size_t length
 // SipHash
 uint64_t hashSipHash(const void*  rs, const uint64_t *  string, const size_t length) {
     uint64_t answer;
-    siphash((uint8_t * ) &answer, (const uint8_t * )string, length *sizeof(uint64_t),rs );
+    siphash((uint8_t * ) &answer, (const uint8_t * )string, length *sizeof(uint64_t), (const uint8_t *)rs );
     return answer;
 }
 

--- a/makefile
+++ b/makefile
@@ -25,8 +25,8 @@ benchmark128bitpolyhashing: src/benchmark128bitpolyhashing.c include/clmul.h
 benchmark64bitreductions: src/benchmark64bitreductions.c include/clmul.h  
 	$(CC) $(CFLAGS) -o benchmark64bitreductions src/benchmark64bitreductions.c   -Iinclude 
 
-variablelengthbenchmark: src/variablelengthbenchmark.c include/*.h City.o siphash24.o vmac.o 
-	$(CC) $(CFLAGS) -o variablelengthbenchmark src/variablelengthbenchmark.c City.o siphash24.o vmac.o rijndael-alg-fst.o  -Iinclude -ICity -ISipHash -IVHASH 
+variablelengthbenchmark: src/variablelengthbenchmark.cc include/*.h City.o siphash24.o vmac.o 
+	$(CXX) $(CXXFLAGS) -o variablelengthbenchmark src/variablelengthbenchmark.cc City.o siphash24.o vmac.o rijndael-alg-fst.o  -Iinclude -ICity -ISipHash -IVHASH 
 
 clmulunit: src/clmulunit.c include/*.h
 	$(CC) $(CFLAGS) -o clmulunit src/clmulunit.c -Iinclude 

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@
 .SUFFIXES: .cpp .o .c .h
 
 CFLAGS = -std=gnu99 -ggdb  -O2 -mavx  -march=native -Wall -Wextra -funroll-loops
-CXXFLAGS = -O2 -mavx  -march=native
+CXXFLAGS = -O2 -mavx  -march=native -std=c++0x
 
 all: clmulunit variablelengthbenchmark  benchmark benchmark64bitreductions uniformsanity smhasher benchmark128bitmultiplication benchmark128bitpolyhashing
 

--- a/src/variablelengthbenchmark.cc
+++ b/src/variablelengthbenchmark.cc
@@ -67,6 +67,7 @@ ticks stopRDTSCP(void) {
  return ((ticks) cycles_high << 32) | cycles_low;
  }*/
 
+extern "C" {
 #include "hashfunctions32bits.h"
 #include "hashfunctions64bits.h"
 
@@ -76,6 +77,7 @@ ticks stopRDTSCP(void) {
 #include "clmulhierarchical64bits.h"
 #include "ghash.h"
 #include "bigendianuniversal.h"
+}
 
 #define HowManyFunctions64 8
 
@@ -115,7 +117,7 @@ int main(int c, char ** arg) {
     struct timeval start, finish;
     uint64_t randbuffer[150] __attribute__ ((aligned (16)));// 150 should be plenty
     uint32_t sumToFoolCompiler = 0;
-    uint64_t * intstring = malloc(N * sizeof(uint64_t)); // // could force 16-byte alignment with  __attribute__ ((aligned (16)));
+    uint64_t * intstring = (uint64_t *)malloc(N * sizeof(uint64_t)); // // could force 16-byte alignment with  __attribute__ ((aligned (16)));
     for (i = 0; i < 150; ++i) {
         randbuffer[i] = rand() | ((uint64_t)(rand()) << 32);
     }


### PR DESCRIPTION
This will enable the use of templates, rather than macros, for
meta-programming like that done in bigendianuniversal.h for different
chunk sizes.
