### PR TITLE
Add test that hash functions use all of their input

### DIFF
--- a/include/treehash/simple-treehash.hh
+++ b/include/treehash/simple-treehash.hh
@@ -92,7 +92,7 @@ split_generic_simple_treehash_without_length(const void **rvoid,
   T prefill(rvoid, 64 - __builtin_clzll(N));
   return generic_simple_treehash_without_length(
       prefill, level,
-      N + (length + sizeof(Atom) / sizeof(uint64_t) - 1) / sizeof(Atom), level);
+      N + (length + sizeof(Atom) - 1) / sizeof(Atom), level);
 }
 
 uint64_t simple_treehash(const void *rvoid, const uint64_t *data,

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@
 .phony: all clean smhasherpackage-submake
 
 FLAGS = -ggdb -O2 -mavx -mavx2 -march=native -Wall -Wextra -Wstrict-overflow -Wstrict-aliasing -funroll-loops
-DEBUGFLAGS = $(FLAGS) -ggdb3 -O0 -fno-unroll-loops -fsanitize=undefined
+DEBUGFLAGS = $(FLAGS) -ggdb3 -O0 -fno-unroll-loops #-fsanitize=undefined
 CFLAGS = $(FLAGS) -std=gnu99
 CDEBUGFLAGS = $(DEBUGFLAGS) -std=gnu99
 CXXFLAGS = $(FLAGS) -std=c++0x
@@ -35,6 +35,12 @@ benchmark64bitreductions: src/benchmark64bitreductions.c include/clmul.h
 
 classicvariablelengthbenchmark: src/classicvariablelengthbenchmark.c include/*.h City.o siphash24.o vmac.o 
 	$(CC) $(CFLAGS) -o classicvariablelengthbenchmark src/classicvariablelengthbenchmark.c City.o siphash24.o vmac.o rijndael-alg-fst.o  -Iinclude -ICity -ISipHash -IVHASH
+
+unused: src/unused.cc include/*.h include/treehash/*.hh City.o siphash24.o vmac.o 
+	$(CXX) $(CXXFLAGS) -o unused src/unused.cc City.o siphash24.o vmac.o rijndael-alg-fst.o  -Iinclude -ICity -ISipHash -IVHASH 
+
+unused-debug: src/unused.cc include/*.h include/treehash/*.hh City.o siphash24.o vmac.o 
+	$(CXX) $(CXXDEBUGFLAGS) -o unused-debug src/unused.cc City.o siphash24.o vmac.o rijndael-alg-fst.o  -Iinclude -ICity -ISipHash -IVHASH 
 
 variablelengthbenchmark: src/variablelengthbenchmark.cc include/*.h include/treehash/*.hh City.o siphash24.o vmac.o 
 	$(CXX) $(CXXFLAGS) -o variablelengthbenchmark src/variablelengthbenchmark.cc City.o siphash24.o vmac.o rijndael-alg-fst.o  -Iinclude -ICity -ISipHash -IVHASH 

--- a/src/unused.cc
+++ b/src/unused.cc
@@ -1,0 +1,102 @@
+// CHeck that every word in an input string is used in the output, by
+// varying that word and seeing that it changes the output.
+
+#include <cassert>
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string.h>
+
+#include <iostream>
+
+using namespace std;
+
+extern "C" {
+#include "hashfunctions64bits.h"
+}
+
+#include "treehash/binary-treehash.hh"
+#include "treehash/generic-treehash.hh"
+
+struct NamedFunc {
+  const hashFunction64 f;
+  const string name;
+  NamedFunc(const hashFunction64& f, const string& name) : f(f), name(name) {}
+};
+
+#define NAMED(f) NamedFunc(f, #f)
+
+NamedFunc hashFunctions[] = {
+    NAMED((&generic_treehash<BoostedZeroCopyGenericBinaryTreehash, CLNH, 1>)),
+};
+//    NAMED((&generic_treehash<BoostedZeroCopyGenericBinaryTreehash, NHCL, 7>)),
+//    NAMED((&generic_treehash<BoostedZeroCopyGenericBinaryTreehash, NH, 7>))};
+
+const int HowManyFunctions64 =
+    sizeof(hashFunctions) / sizeof(hashFunctions[0]);
+
+int main(int c, char ** arg) {
+    (void) (c);
+    (void) (arg);
+    uint64_t which_algos = ~0;
+    assert(HowManyFunctions64 <= 64);
+    if (c > 1) {
+      if (1 != sscanf(arg[1], "%" SCNu64, &which_algos)) {
+        return 1;
+      }
+    }
+    int lengthStart = 1, lengthEnd = 2048; // inclusive
+    if (c > 2)
+        lengthStart = atoi(arg[2]);
+    if (c > 3)
+        lengthEnd = atoi(arg[3]);
+
+    int i;
+    int length;
+    uint64_t randbuffer[150] __attribute__ ((aligned (16)));// 150 should be plenty
+
+    uint64_t * intstring;
+    // We need 32 bytes of alignment for working with __m256i's
+    if (posix_memalign((void **)(&intstring), 32, sizeof(uint64_t)*lengthEnd)) {
+      cerr << "Failed to allocate " << lengthEnd << " words." << endl;
+      return 1;
+    }
+    for (i = 0; i < 150; ++i) {
+        randbuffer[i] = rand() | ((uint64_t)(rand()) << 32);
+    }
+    for (i = 0; i < lengthEnd; ++i) {
+        intstring[i] = rand() | ((uint64_t)(rand()) << 32);
+    }
+    for (length = lengthStart; length <= lengthEnd; length += 1) {
+      //printf("%8d \t\t", length);
+      cout << length << " ";
+      for (int place = 0; place < length; ++place) {
+        for (i = 0; i < HowManyFunctions64; ++i) {
+            if (!(which_algos & (0x1ull << i)))
+                continue;  // skip unselected algos
+            const hashFunction64 thisfunc64 = hashFunctions[i].f;
+            const auto first_run = thisfunc64(randbuffer, intstring, length);
+            const auto old_val = intstring[place];
+            const uint64_t new_val = old_val + 1; //rand() || ((uint64_t)(rand()) << 32);
+            intstring[place] = new_val;
+            const auto second_run = thisfunc64(randbuffer, intstring, length);
+            if (first_run == second_run) {
+              cerr << "uhoh: " << length << " " << place << " " << hashFunctions[i].name << endl
+                   << first_run << " " << second_run << endl
+                   << old_val << " " << new_val << endl;
+              const auto old_val2 = intstring[place];
+              const uint64_t new_val2 = old_val2 + 1; //rand() || ((uint64_t)(rand()) << 32);
+              intstring[place] = new_val2;
+              const auto second_run2 = thisfunc64(randbuffer, intstring, length);
+              if (second_run2 == second_run) {
+                cerr << second_run << " " << second_run2 << endl
+                     << new_val << " " << new_val2 << endl;
+              }
+            }
+        }
+        }
+        //printf("\n");
+    }
+    free(intstring);
+}


### PR DESCRIPTION
This showed some bugs in some treehashes. Fixing the bugs resulted in slower code.
