### PR TITLE
Add UMASH to the variable-length benchmark

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "include/umash"]
+	path = include/umash
+	url = https://github.com/backtrace-labs/umash

--- a/include/makefile
+++ b/include/makefile
@@ -1,6 +1,12 @@
 .phony: all City-target SipHash-target VHASH-target PMP-target clean
 
-all: City-target SipHash-target VHASH-target PMP-target
+CFLAGS = $(FLAGS) -fPIC
+CDEBUGFLAGS = $(DEBUGFLAGS) -fPIC
+CXXFLAGS = $(FLAGS) -fPIC
+CXXDEBUGFLAGS = $(DEBUGFLAGS) -fPIC
+export
+
+all: City-target SipHash-target VHASH-target PMP-target umash/umash.o
 
 %-target:
 	$(MAKE) -C $*
@@ -10,3 +16,4 @@ clean:
 	$(MAKE) -C SipHash clean
 	$(MAKE) -C VHASH clean
 	$(MAKE) -C PMP clean
+	rm -f umash/umash.o


### PR DESCRIPTION
UMASH is a hash function that is also based on the pseudo-dot-product
like CLHASH, VHASH, etc. It has tweaks that were needed for
Backtrace's use cases, including running on input that has a length,
in bytes, that is not a multiple of sizeof(uint64_t) and being very
fast on short input.

Adding benchmarks that demonstrate that speed compared to CLHASH is
future work.

For reference, see:

https://github.com/backtrace-labs/umash

https://engineering.backtrace.io/2020-08-24-umash-fast-enough-almost-universal-fingerprinting